### PR TITLE
chore: expose more info in err log

### DIFF
--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -46,7 +46,8 @@ func (s *Service) watchForSpendStakingTx(
 			stakingTxHashHex,
 		); err != nil {
 			log.Error().
-				Err(err).
+				Interface("error", err).
+				Stack().
 				Str("staking_tx", stakingTxHashHex).
 				Str("spending_tx", spendDetail.SpendingTx.TxHash().String()).
 				Msg("failed to handle spending staking transaction")


### PR DESCRIPTION
I am seeing this log often which is bit weird to me, there is no error information printed maybe the logger doesn't like err struct. 

```
{
  "level": "error",
  "staking_tx": "e89434eb5472c17b07e18b4532c813d0ff03dd22e2fb02ff936219e770786e68",
  "spending_tx": "8fedf9917b754dcba0b8c7634fe4f84c84833f524b9ab4299c5680c2f73b9788",
  "time": "2025-01-10T12:44:06Z",
  "message": "failed to handle spending staking transaction"
}
```
