### PR TITLE
BTC auto retry wrapper

### DIFF
--- a/internal/btcclient/btcclient.go
+++ b/internal/btcclient/btcclient.go
@@ -5,15 +5,23 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/rs/zerolog/log"
 
 	"github.com/babylonlabs-io/staking-expiry-checker/internal/config"
 	"github.com/babylonlabs-io/staking-expiry-checker/internal/observability/metrics"
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/wire"
 )
 
+type client interface {
+	GetBlockCount() (int64, error)
+	GetBlockHash(int64) (*chainhash.Hash, error)
+	GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader, error)
+	GetTxOut(*chainhash.Hash, uint32, bool) (*btcjson.GetTxOutResult, error)
+}
+
 type BtcClient struct {
-	client *rpcclient.Client
+	client client
 	cfg    *config.BTCConfig
 }
 
@@ -23,7 +31,7 @@ func NewBtcClient(cfg *config.BTCConfig) (*BtcClient, error) {
 		return nil, err
 	}
 
-	rpcClient, err := rpcclient.New(connCfg, nil)
+	rpcClient, err := newRPCClientWithReconect(connCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/btcclient/reconnect.go
+++ b/internal/btcclient/reconnect.go
@@ -1,12 +1,13 @@
 package btcclient
 
 import (
+	"strings"
+	"sync"
+
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
-	"strings"
-	"sync"
 )
 
 type rpcClientWithReconnect struct {

--- a/internal/btcclient/reconnect.go
+++ b/internal/btcclient/reconnect.go
@@ -1,0 +1,135 @@
+package btcclient
+
+import (
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/wire"
+	"strings"
+	"sync"
+)
+
+type rpcClientWithReconnect struct {
+	cfg       *rpcclient.ConnConfig
+	rpcClient *rpcclient.Client
+	mx        sync.RWMutex
+}
+
+func newRPCClientWithReconect(cfg *rpcclient.ConnConfig) (*rpcClientWithReconnect, error) {
+	client, err := rpcclient.New(cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpcClientWithReconnect{
+		cfg:       cfg,
+		rpcClient: client,
+	}, nil
+}
+
+func (r *rpcClientWithReconnect) GetBlockCount() (int64, error) {
+	r.mx.RLock()
+	block, err := r.rpcClient.GetBlockCount()
+	r.mx.RUnlock()
+
+	if err != nil {
+		if r.isTimeout(err) {
+			r.reconnect()
+			return r.rpcClient.GetBlockCount()
+		}
+
+		return 0, err
+	}
+
+	return block, nil
+}
+
+func (r *rpcClientWithReconnect) GetBlockHash(block int64) (*chainhash.Hash, error) {
+	r.mx.RLock()
+	hash, err := r.rpcClient.GetBlockHash(block)
+	r.mx.RUnlock()
+
+	if err != nil {
+		if r.isTimeout(err) {
+			r.reconnect()
+			return r.rpcClient.GetBlockHash(block)
+		}
+
+		return nil, err
+	}
+
+	return hash, nil
+}
+
+func (r *rpcClientWithReconnect) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	r.mx.RLock()
+	result, err := r.rpcClient.GetBlockHeader(hash)
+	r.mx.RUnlock()
+
+	if err != nil {
+		if r.isTimeout(err) {
+			r.reconnect()
+			return r.rpcClient.GetBlockHeader(hash)
+		}
+
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *rpcClientWithReconnect) GetTxOut(hash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error) {
+	r.mx.RLock()
+	result, err := r.rpcClient.GetTxOut(hash, index, mempool)
+	r.mx.RUnlock()
+
+	if err != nil {
+		if r.isTimeout(err) {
+			r.reconnect()
+			return r.rpcClient.GetTxOut(hash, index, mempool)
+		}
+
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *rpcClientWithReconnect) GetBlock(hash *chainhash.Hash) (*wire.MsgBlock, error) {
+	r.mx.RLock()
+	block, err := r.rpcClient.GetBlock(hash)
+	r.mx.RUnlock()
+
+	if err != nil {
+		if r.isTimeout(err) {
+			r.reconnect()
+			return r.rpcClient.GetBlock(hash)
+		}
+
+		return nil, err
+	}
+
+	return block, nil
+}
+
+func (r *rpcClientWithReconnect) reconnect() {
+	client, err := rpcclient.New(r.cfg, nil)
+	if err != nil {
+		// we don't need to modify r.rpcClient here
+		// otherwise it can trigger nil pointer dereference in other methods
+		return
+	}
+
+	r.mx.Lock()
+	r.rpcClient = client
+	r.mx.Unlock()
+}
+
+func (r *rpcClientWithReconnect) isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// unfortunately rpcclient returns root cause like string, errors.Is or errors.As won't help
+	return strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers")
+}

--- a/internal/btcclient/reconnect_test.go
+++ b/internal/btcclient/reconnect_test.go
@@ -2,11 +2,12 @@ package btcclient
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/babylonlabs-io/staking-expiry-checker/internal/config"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestReconnect(t *testing.T) {
@@ -35,5 +36,4 @@ func TestReconnect(t *testing.T) {
 		require.NoError(t, err)
 		spew.Dump(count)
 	}
-
 }

--- a/internal/btcclient/reconnect_test.go
+++ b/internal/btcclient/reconnect_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestReconnect(t *testing.T) {
-	// t.Skip("Manual")
+	t.Skip("Manual")
 
 	cfg := &config.BTCConfig{
 		RPCHost:              "127.0.0.30:18443",

--- a/internal/btcclient/reconnect_test.go
+++ b/internal/btcclient/reconnect_test.go
@@ -1,0 +1,39 @@
+package btcclient
+
+import (
+	"fmt"
+	"github.com/babylonlabs-io/staking-expiry-checker/internal/config"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestReconnect(t *testing.T) {
+	// t.Skip("Manual")
+
+	cfg := &config.BTCConfig{
+		RPCHost:              "127.0.0.30:18443",
+		RPCUser:              "user",
+		RPCPass:              "pass",
+		BlockPollingInterval: time.Second,
+		TxPollingInterval:    time.Second,
+		BlockCacheSize:       20 * 1024 * 1024, // 20 MB
+		MaxRetryTimes:        1,
+		RetryInterval:        time.Millisecond,
+		NetParams:            "regtest",
+	}
+	connCfg, err := cfg.ToConnConfig()
+	require.NoError(t, err)
+
+	cl, err := newRPCClientWithReconect(connCfg)
+	require.NoError(t, err)
+
+	for i := range 2 {
+		fmt.Printf("Iteration %d\n", i)
+		count, err := cl.GetBlockCount()
+		require.NoError(t, err)
+		spew.Dump(count)
+	}
+
+}


### PR DESCRIPTION
Issue #58 

First of all, the btcd/rpcclient API is one of the strangest and dumbest I’ve ever worked with — you’ll see why in a second.

Here’s the scenario:

We start a service with btc.rpchost pointing to some DNS name.
Inside rpcclient.New(...), they create an HTTP client (note that we always go through the HTTPPostMode branch).
Here’s how it’s created (function newHTTPClient):
```
parsedAddr, err := ParseAddressString(config.Host)
if err != nil {
   return nil, err
}
client := http.Client{
   Transport: &http.Transport{
      Proxy:           proxyFunc,
      TLSClientConfig: tlsConfig,
      DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
         return net.Dial(parsedAddr.Network(), parsedAddr.String())
      },
   },
   Timeout: defaultHTTPTimeout,
}
```

This means they parse and resolve the host once and reuse it indefinitely.

Now, what happens if the Kubernetes DNS name starts pointing to another service?
The DNS now resolves to a new IP, but since it was already resolved earlier, btcclient continues using the old IP — which is already gone. :facepalm:

And here’s another weird design decision:

There’s no way to control the timeout of the http.Client they use. So, if the resolved IP is unreachable (e.g., no such IP or no route to host — not sure which in our case), it will wait for the default time.Minute.
On top of that, they implemented their own hardcoded backoff logic: 10 retries.

So basically, it waits ~10 minutes before giving up.

Given all that, I managed to create a wrapper that safely “reconnects” (by recreating the client to the BTC node), but the timeout problem is unresolvable.

The only other option would be to find a different client — but that’s extremely risky right now.