### PR TITLE
chore: update reusable docker pipeline to v0.18.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       gosec-args: "-no-fail ./..."
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106 # v0.13.4
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     secrets: inherit
     with:
       publish: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
       run-unit-tests: true
       run-integration-tests: false
       run-lint: true
-     
+
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@22ae8ed7a2ea5c80331758914c4e0ea732eea1ad # v0.15.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     secrets: inherit
     permissions:
       contents: read        # REQUIRED by reusable workflow


### PR DESCRIPTION
## Summary

- Update `reusable_docker_pipeline.yml` to v0.18.1 (`0adff9d36a`)

### What's new in v0.18.1

- Scan-before-push: images are scanned locally before any registry push
- 4-scan model: filesystem vulns, filesystem secrets, image vulns, image secrets
- Secret scanning for source code and Docker layers (CRITICAL, HIGH)
- SARIF upload to GitHub Security tab (public repos)
- Scan results in GitHub Actions Job Summary
- Hadolint lint failures block image publishing