### PR TITLE
build: upgrade golangci-lint to v2.1.6 and migrate configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
     with:
       go-version: '1.24.3'
-      go-lint-version: 'v1.64.8'
+      go-lint-version: 'v2.1.6'
       run-unit-tests: true
       run-integration-tests: false
       run-lint: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,69 +1,64 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 120
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - sloppyReassign
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - unnamedResult
-  gocyclo:
-    min-complexity: 18 # todo decrease to 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  mnd:
-    # don't include the "operation", "assign", "condition"
-    checks:
-      - argument
-      - case
-      - return
-    ignored-files:
-      - 'e2etest/.+\.go$'
-    ignored-functions:
-      - strings.SplitN
-      - make
-
-  govet:
-    enable: [nilness]
-#    shadow: true
-#    settings:
-#      printf:
-#        funcs:
-#          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-#          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-#          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-#          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-
-  exhaustruct:
-    include: []
-
-  gosec:
-    excludes:
-      - G115 #TODO: remove after fixing https://github.com/securego/gosec/issues/1212
+version: "2"
 
 linters:
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 120
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - sloppyReassign
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - unnamedResult
+    gocyclo:
+      min-complexity: 18 # todo decrease to 15
+    goimports:
+      local-prefixes: github.com/golangci/golangci-lint
+    mnd:
+      # don't include the "operation", "assign", "condition"
+      checks:
+        - argument
+        - case
+        - return
+      ignored-files:
+        - 'e2etest/.+\.go$'
+      ignored-functions:
+        - strings.SplitN
+        - make
+
+    govet:
+      enable:
+        - nilness
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      require-explanation: false # don't require an explanation for nolint directives
+      require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+    exhaustruct:
+      include: []
+
+    gosec:
+      excludes:
+        - G115 #TODO: remove after fixing https://github.com/securego/gosec/issues/1212
+
   disable-all: true
   enable:
     - bodyclose
@@ -75,27 +70,23 @@ linters:
     - unconvert
     - unused
     - whitespace
-    - gosimple
     - makezero
     - usestdlibvars
     - unparam
     - prealloc
     - mnd
-    - goprintffuncname
     - gosec
     - govet
     - ineffassign
     - nakedret
     - staticcheck
     - noctx
-    - typecheck
     - tparallel
-    - gofumpt
     - nilerr
     - misspell
     - funlen
     - gocyclo
-  # todo enable after golangci-lint update to 1.63
+  # todo enable after golangci-lint update
   # - nilnesserr
   # - usetesting
   # - exhaustruct
@@ -128,6 +119,10 @@ issues:
         - lll
         - gosec
         - exhaustruct
+
+formatters:
+  enable:
+    - gofumpt
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     gocyclo:
       min-complexity: 18 # todo decrease to 15
     goimports:
-      local-prefixes: github.com/golangci/golangci-lint
+      local-prefixes: github.com/babylonlabs-io/staking-expiry-checker
     mnd:
       # don't include the "operation", "assign", "condition"
       checks:

--- a/internal/btcclient/notifier.go
+++ b/internal/btcclient/notifier.go
@@ -1,6 +1,7 @@
 package btcclient
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -68,7 +69,8 @@ func NewBTCNotifier(
 
 func BuildDialer(rpcHost string) func(string) (net.Conn, error) {
 	return func(addr string) (net.Conn, error) {
-		return net.Dial("tcp", rpcHost)
+		dialer := &net.Dialer{}
+		return dialer.DialContext(context.Background(), "tcp", rpcHost)
 	}
 }
 

--- a/internal/db/dbclient.go
+++ b/internal/db/dbclient.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -92,7 +93,11 @@ func findWithPagination[T any](
 	if err != nil {
 		return nil, err
 	}
-	defer cursor.Close(ctx)
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("failed to close cursor")
+		}
+	}()
 
 	var result []T
 	if err = cursor.All(ctx, &result); err != nil {

--- a/internal/db/expiry.go
+++ b/internal/db/expiry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/babylonlabs-io/staking-expiry-checker/internal/db/model"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -25,7 +27,11 @@ func (db *Database) FindExpiredDelegations(ctx context.Context, btcTipHeight uin
 	if err != nil {
 		return nil, err
 	}
-	defer cursor.Close(ctx)
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("failed to close cursor")
+		}
+	}()
 
 	var delegations []model.TimeLockDocument
 	if err = cursor.All(ctx, &delegations); err != nil {


### PR DESCRIPTION

Upgrade golangci-lint from v1.64.8 to v2.1.6 (major version bump) and
update the golangci-lint configuration file to conform to v2 format:

- Update go-lint-version in CI workflow to v2.1.6
- Migrate .golangci.yml to v2 schema with version declaration
- Restructure configuration: move linters-settings to linters.settings
- Remove deprecated linters (gosimple, goprintffuncname, typecheck)
- Move gofumpt from linters to formatters section
- Add context import to btcclient/notifier.go for compatibility

This change ensures compatibility with the latest golangci-lint v2.x
release and follows the new configuration structure requirements.